### PR TITLE
Clean up code for Airtable API calls

### DIFF
--- a/airtable.js
+++ b/airtable.js
@@ -1,5 +1,4 @@
 /* eslint no-restricted-imports: 0 */
-
 /*
   THIS IS A GENERATED FILE
   Changes might be overwritten in the future, edit with caution!
@@ -9,13 +8,12 @@
 
   If you're adding a new function: make sure you add a corresponding test (at least 1) for it in airtable.spec.js
 */
+import Airtable from "airtable";
+import { Columns } from "./schema";
 
-import Airtable from 'airtable';
-import { Columns } from './schema';
-
-const BASE_ID = 'REPLACE_BASE_ID';
-const VIEW = 'REPLACE_VIEW';
-const ENDPOINT_URL = 'https://api.airtable.com';
+const BASE_ID = "REPLACE_BASE_ID";
+const VIEW = "REPLACE_VIEW";
+const ENDPOINT_URL = "https://api.airtable.com";
 
 const apiKey = process.env.REACT_APP_AIRTABLE_API_KEY;
 
@@ -58,7 +56,7 @@ const fromAirtableFormat = (record, table) => {
     let value = record[origColumn];
 
     // Unwrap array if it's a single foreign key relationship
-    if (jsFormattedName.type === 'foreignKey-one') {
+    if (jsFormattedName.type === "foreignKey-one") {
       [value] = value; // Array Destructuring
     }
 
@@ -87,7 +85,7 @@ const toAirtableFormat = (record, table) => {
     }
 
     let value = record[jsFormattedColumnName];
-    if (origColumn.type === 'foreignKey-one') {
+    if (origColumn.type === "foreignKey-one") {
       value = [value]; // rewrap array if it's a single foreign key relationship
     }
 
@@ -98,127 +96,13 @@ const toAirtableFormat = (record, table) => {
 // ******** CRUD ******** //
 // Given a table and a record object, create a record on Airtable.
 function createRecord(table, record) {
-  return new Promise(function(resolve, reject) {
-    const transformedRecord = toAirtableFormat(record, table);
-    base(table).create([{ fields: transformedRecord }], function(err, records) {
-      if (err) {
-        reject(err);
-        return;
-      }
-
-      const expectedLen = 1;
-      if (records.length !== expectedLen) {
-        reject(
-          new Error(
-            `${records.length} records returned from creating 1 record. Expected: ${expectedLen}`
-          )
-        );
-        return;
-      }
-
-      resolve(records[0].getId());
-    });
-  });
-}
-
-// TODO pagination?
-// TODO: current implementation only fetches the first page
-function getAllRecords(table) {
-  return new Promise(function(resolve, reject) {
+  const transformedRecord = toAirtableFormat(record, table);
+  return new Promise(function process(resolve, reject) {
     base(table)
-      .select({
-        view: VIEW
-      })
-      .eachPage(
-        function page(records, fetchNextPage) {
-          if (records === null || records.length < 1) {
-            const msg = `No record was retrieved using this ${table}.`;
-            reject(msg);
-            return;
-          }
-
-          resolve(
-            records.map(record => fromAirtableFormat(record.fields, table))
-          );
-
-          // To fetch the next page of records, call `fetchNextPage`.
-          // If there are more records, `page` will get called again.
-          // If there are no more records, `done` will get called.
-          fetchNextPage();
-        },
-        function done(err) {
-          if (err) {
-            reject(err);
-          }
-        }
-      );
-  });
-}
-
-// Given a table and record ID, return the associated record object using a Promise.
-function getRecordById(table, id) {
-  return new Promise(function(resolve, reject) {
-    base(table).find(id, function(err, record) {
-      if (err) {
-        reject(err);
-        return;
-      }
-
-      resolve(fromAirtableFormat(record.fields, table));
-    });
-  });
-}
-
-// TODO: current implementation only returns the first page
-/*
-  Given the desired table, field type (column), and field ('nick wong' or 'aivant@pppower.io'),
-  return the associated record object.
-*/
-function getRecordsByAttribute(table, fieldType, field) {
-  return new Promise(function(resolve, reject) {
-    base(table)
-      .select({
-        view: VIEW,
-        filterByFormula: `{${fieldType}}='${field}'`
-      })
-      .firstPage((err, records) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        if (!records || records.length < 1) {
-          console.log(`No record was retrieved using this ${fieldType}.`);
-          resolve([]);
-          // No need for this to throw an error, sometimes there's just no values
-          // reject(new Error(`No record was retrieved using this ${fieldType}.`));
-          return;
-        }
-
-        resolve(
-          records.map(record => fromAirtableFormat(record.fields, table))
-        );
-      });
-  });
-}
-
-// Given a table and a record object, update a record on Airtable.
-function updateRecord(table, id, updatedRecord) {
-  return new Promise(function(resolve, reject) {
-    const transformedRecord = toAirtableFormat(updatedRecord, table);
-    base(table).update(
-      [
-        {
-          id,
-          fields: transformedRecord
-        }
-      ],
-      function(err, records) {
-        if (err) {
-          reject(err);
-          return;
-        }
-
+      .create([{ fields: transformedRecord }])
+      .then(records => {
         const expectedLen = 1;
+        // TODO will this error ever be triggered? It seems like AirTable should catch and throw this error
         if (records.length !== expectedLen) {
           reject(
             new Error(
@@ -228,32 +112,110 @@ function updateRecord(table, id, updatedRecord) {
           return;
         }
 
-        resolve(records[0].id); // TODO
-      }
-    );
+        resolve(records[0].getId());
+      })
+      .catch(err => reject(err));
   });
 }
 
-function deleteRecord(table, id) {
-  return new Promise(function(resolve, reject) {
-    base(table).destroy([id], function(err, deletedRecords) {
-      if (err) {
-        reject(err);
-        return;
-      }
-      const expectedLen = 1;
-      if (deletedRecords.length !== expectedLen) {
-        reject(
-          new Error(
-            `${deletedRecords.length} records returned from deleting ${expectedLen} record(s). Expected: ${expectedLen}`
-          )
-        );
-        return;
+function getAllRecords(table, filterByFormula = "", sort = []) {
+  return base(table)
+    .select({
+      view: VIEW,
+      filterByFormula,
+      sort
+    })
+    .all()
+    .then(records => {
+      if (records === null || records.length < 1) {
+        const msg = `No record was retrieved using this ${table}.`;
+        throw new Error(msg);
       }
 
-      resolve(deletedRecords[0].fields);
+      return records.map(record => fromAirtableFormat(record.fields, table));
+    })
+    .catch(err => {
+      throw err;
     });
-  });
+}
+
+// Given a table and record ID, return the associated record object using a Promise.
+function getRecordById(table, id) {
+  return base(table)
+    .find(id)
+    .then(record => {
+      return fromAirtableFormat(record.fields, table);
+    })
+    .catch(err => {
+      throw err;
+    });
+}
+
+/*
+  Given the desired table, field type (column), and field ('nick wong' or 'aivant@pppower.io'),
+  return the associated record object.
+*/
+function getRecordsByAttribute(table, fieldType, field, sort = []) {
+  return base(table)
+    .select({
+      view: VIEW,
+      filterByFormula: `{${fieldType}}='${field}'`,
+      sort
+    })
+    .all()
+    .then(records => {
+      if (!records || records.length < 1) {
+        console.log(`No record was retrieved using this ${fieldType}.`);
+        return [];
+        // No need for this to throw an error, sometimes there're just no values
+      }
+
+      return records.map(record => fromAirtableFormat(record.fields, table));
+    })
+    .catch(err => {
+      throw err;
+    });
+}
+
+// Given a table and a record object, update a record on Airtable.
+function updateRecord(table, id, updatedRecord) {
+  const transformedRecord = toAirtableFormat(updatedRecord, table);
+  return base(table)
+    .update([
+      {
+        id,
+        fields: transformedRecord
+      }
+    ])
+    .then(records => {
+      const expectedLen = 1;
+      if (records.length !== expectedLen) {
+        throw new Error(
+          `${records.length} records returned from updating 1 record. Expected: ${expectedLen}`
+        );
+      }
+      return records[0].id;
+    })
+    .catch(err => {
+      throw err;
+    });
+}
+
+function deleteRecord(table, id) {
+  return base(table)
+    .destroy([id])
+    .then(records => {
+      const expectedLen = 1;
+      if (records.length !== expectedLen) {
+        throw new Error(
+          `${records.length} records returned from deleting ${expectedLen} record(s). Expected: ${expectedLen}`
+        );
+      }
+      return records[0].fields;
+    })
+    .catch(err => {
+      throw err;
+    });
 }
 
 export {

--- a/airtable.js
+++ b/airtable.js
@@ -8,12 +8,12 @@
 
   If you're adding a new function: make sure you add a corresponding test (at least 1) for it in airtable.spec.js
 */
-import Airtable from "airtable";
-import { Columns } from "./schema";
+import Airtable from 'airtable';
+import { Columns } from './schema';
 
-const BASE_ID = "REPLACE_BASE_ID";
-const VIEW = "REPLACE_VIEW";
-const ENDPOINT_URL = "https://api.airtable.com";
+const BASE_ID = 'REPLACE_BASE_ID';
+const VIEW = 'REPLACE_VIEW';
+const ENDPOINT_URL = 'https://api.airtable.com';
 
 const apiKey = process.env.REACT_APP_AIRTABLE_API_KEY;
 
@@ -56,7 +56,7 @@ const fromAirtableFormat = (record, table) => {
     let value = record[origColumn];
 
     // Unwrap array if it's a single foreign key relationship
-    if (jsFormattedName.type === "foreignKey-one") {
+    if (jsFormattedName.type === 'foreignKey-one') {
       [value] = value; // Array Destructuring
     }
 
@@ -85,7 +85,7 @@ const toAirtableFormat = (record, table) => {
     }
 
     let value = record[jsFormattedColumnName];
-    if (origColumn.type === "foreignKey-one") {
+    if (origColumn.type === 'foreignKey-one') {
       value = [value]; // rewrap array if it's a single foreign key relationship
     }
 
@@ -118,7 +118,7 @@ function createRecord(table, record) {
   });
 }
 
-function getAllRecords(table, filterByFormula = "", sort = []) {
+function getAllRecords(table, filterByFormula = '', sort = []) {
   return base(table)
     .select({
       view: VIEW,

--- a/airtable.js
+++ b/airtable.js
@@ -101,17 +101,6 @@ function createRecord(table, record) {
     base(table)
       .create([{ fields: transformedRecord }])
       .then(records => {
-        const expectedLen = 1;
-        // TODO will this error ever be triggered? It seems like AirTable should catch and throw this error
-        if (records.length !== expectedLen) {
-          reject(
-            new Error(
-              `${records.length} records returned from creating 1 record. Expected: ${expectedLen}`
-            )
-          );
-          return;
-        }
-
         resolve(records[0].getId());
       })
       .catch(err => reject(err));
@@ -188,12 +177,6 @@ function updateRecord(table, id, updatedRecord) {
       }
     ])
     .then(records => {
-      const expectedLen = 1;
-      if (records.length !== expectedLen) {
-        throw new Error(
-          `${records.length} records returned from updating 1 record. Expected: ${expectedLen}`
-        );
-      }
       return records[0].id;
     })
     .catch(err => {
@@ -205,12 +188,6 @@ function deleteRecord(table, id) {
   return base(table)
     .destroy([id])
     .then(records => {
-      const expectedLen = 1;
-      if (records.length !== expectedLen) {
-        throw new Error(
-          `${records.length} records returned from deleting ${expectedLen} record(s). Expected: ${expectedLen}`
-        );
-      }
       return records[0].fields;
     })
     .catch(err => {

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -72,7 +72,6 @@ function generateSchemaFile(schema, settings) {
 }
 
 module.exports = {
-  generateConstantsFile,
   generateRequestFile,
   generateSchemaFile,
   generateAirtableFile

--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -18,6 +18,9 @@ const cleanColumnName = column => {
 
 const cleanTableName = name => name.replace(/\(|\)|\s/g, '');
 
+const pluralize = name =>
+  name.charAt(name.length - 1) === 's' ? name : name.concat('s');
+
 const lowercaseFirstChar = s => {
   return s.charAt(0).toLowerCase() + s.substring(1);
 };
@@ -85,9 +88,7 @@ export const get${tableName}ById = async id => {
   return getRecordById(Tables.${tableName}, id);
 };
 
-export const getAll${tableName}${
-      tableName.charAt(tableName.length - 1).toLowerCase === 's' ? '' : 's'
-    } = async () => { 
+export const getAll${pluralize(tableName)} = async () => { 
   return getAllRecords(Tables.${tableName});
 };
 `;
@@ -95,7 +96,7 @@ export const getAll${tableName}${
       lookupFields.forEach(field => {
         let cleanName = cleanColumnName({ name: field });
         result += `
-export const get${tableName}sBy${cleanName} = async value => { 
+export const get${pluralize(tableName)}By${cleanName} = async value => { 
     return getRecordsByAttribute(Tables.${tableName}, Columns[Tables.${tableName}].${lowercaseFirstChar(
           cleanName
         )}.name, value);

--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -88,18 +88,22 @@ export const get${tableName}ById = async id => {
   return getRecordById(Tables.${tableName}, id);
 };
 
-export const getAll${pluralize(tableName)} = async () => { 
-  return getAllRecords(Tables.${tableName});
+export const getAll${pluralize(
+      tableName
+    )} = async (filterByFormula = '', sort = []) => { 
+  return getAllRecords(Tables.${tableName}, filterByFormula, sort);
 };
 `;
     if (lookupFields) {
       lookupFields.forEach(field => {
         let cleanName = cleanColumnName({ name: field });
         result += `
-export const get${pluralize(tableName)}By${cleanName} = async value => { 
+export const get${pluralize(
+          tableName
+        )}By${cleanName} = async (value, sort = []) => { 
     return getRecordsByAttribute(Tables.${tableName}, Columns[Tables.${tableName}].${lowercaseFirstChar(
           cleanName
-        )}.name, value);
+        )}.name, value, sort);
 };
 `;
       });

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  singleQuote: true
+};


### PR DESCRIPTION
## What's new

Refactored the template code in `airtable.js` to take advantage of the features added in 0.5.0 of the Airtable API (https://github.com/Airtable/airtable.js/blob/master/CHANGELOG.md)

Notably, these functions do not have to explicitly create and return a promise because it is a Promise-based API; added `.catch` instead of passing the error handler as a function.

Also, added optional `sort` parameters to the relevant getter functions, as well as an optional `filterByFormula` for the `getAllRecords`.

Before creating PR, need to update the generator code for `request.js` to generate the optional parameters for each relevant function as well.

## Issues
closes #16 
closes #17 
closes #18 