### PR TITLE
Added Airlock Support + Overwrite Setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,20 @@ An NPM package designed to support React + Node apps that use Airtable as a back
 - [Important Assumptions](#important-assumptions)
 - [Manual Mode](#manual-mode)
 - [Schema Metadata](#schema-metadata)
-  * [Lookup Fields](#lookup-fields)
+  - [Lookup Fields](#lookup-fields)
 - [Record Transformations](#record-transformations)
 - [Custom Filters and Sorts](#custom-filters-and-sorts)
 - [Notes](#notes)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
-
 ## What it does
 
-After you install and setup the package, running `yarn generate-schema` (or `npm run generate-schema`), the script will scrape the Airtable website, download the latest schema for your app, and generate helper files. 
+After you install and setup the package, running `yarn generate-schema` (or `npm run generate-schema`), the script will scrape the Airtable website, download the latest schema for your app, and generate helper files.
 
 The helper files establish abstraction barriers for the rest of your project to follow. At the lowest level is **`airtable.js`**, which contains the functions that directly interact with airtable. Next, comes **`request.js`**, which are CRUD functions generated for _every_ table in your Airtable base. Finally is **`schema.js`**, a source of truth for your airtable schema.
 
-Besides organizing your code's interactions with airtable via helper functions, the package also makes Airtable records easier to work with! The file `schema.js` contains mappings from Airtable Column Names to a more javascript-y version of them. For example, "First Name" becomes "firstName". It's aware of linked records as well; "Project Group" (which might be a one-to-one linked record column) will become "projectGroupId". 
+Besides organizing your code's interactions with airtable via helper functions, the package also makes Airtable records easier to work with! The file `schema.js` contains mappings from Airtable Column Names to a more javascript-y version of them. For example, "First Name" becomes "firstName". It's aware of linked records as well; "Project Group" (which might be a one-to-one linked record column) will become "projectGroupId".
 
 In your codebase, you can use the javascript-y names, and the provided `airtable.js` file will automatically transform them to and from the actual Airtable column names! See more [here](#record-transformations)
 
@@ -39,43 +38,47 @@ or
 
 #### 2) Choose a mode to use the package in
 
-Options: 
+Options:
+
 1. **Auto**: You will provide your username and password in a `.airtable.env` file and the schema generator will scrape the airtable API page via an automated web browser
 2. **Auto (Headless)**: Same as above, just without a visible web browser
 3. **Manual**: You manually scrape airtable API page and save to file. No username and password needed
 
 #### 3) Add generator settings to your package.json file
 
-In your `package.json` add the following: 
+In your `package.json` add the following:
+
 ```
-"airtable-schema-generator": { 
+"airtable-schema-generator": {
   "mode": "<Desired Mode>",
   "output": "path/to/output/folder"
 }
 ```
 
-The `output` folder is where you'd like your generated files to live. 
+The `output` folder is where you'd like your generated files to live.
 The mode parameter accepts "auto", "auto-headless", and "manual"
 
-**Other Parameters**: 
+**Other Parameters**:
 `input`: Only required if mode is set to Manual. Similar to `output`, specifies where `schemaRaw.json` can be found. Details below
 `defaultView`: You can specify a default view to use for Read requests. Default is "Grid View"
 `schemaMeta`: Where your metadata for schema generation lives. Details below
 `envFileName`: The name of your environment variable file. Default is ".env"
+`airlock`: Boolean parameter as to whether you are using @calblueprint/airlock. Default is `false`
+`overwrite`: Boolean parameter as to whether you want to overwrite the local `airtable.js` file. Default is `true`. Note: When updating schema generator versions, having this set to false might break the code.
 
 #### 4) Create a `.env` file.
 
-Create a file called `.env` in the root of your project and fill it in with the following: 
+Create a file called `.env` in the root of your project and fill it in with the following:
 
 ```
-AIRTABLE_BASE_ID=
-AIRTABLE_API_KEY=
+REACT_APP_AIRTABLE_BASE_ID=
+REACT_APP_AIRTABLE_API_KEY= // Only necessary if not using Airlock
+REACT_APP_AIRTABLE_ENDPOINT_URL= // Only necessary if using airlock
 
 ## Needed if using Auto mode
 AIRTABLE_EMAIL=
 AIRTABLE_PASSWORD=
 ```
-
 
 If you already have a `.env`, you can add these keys to the existing `.env` file. The Email and Password is only needed if using auto mode. This information is only saved on your computer in this hidden file.
 
@@ -90,12 +93,12 @@ Add the line `.env` to your `.gitignore` file
 Update your scripts object in `package.json` to include the following
 
 ```
-"scripts": { 
+"scripts": {
   "generate-schema": "generate-airtable-schema"
 }
 ```
 
-Optional, add ` && pretty-quick` or your own prettifier command to the script to post-process the schema code. 
+Optional, add `&& pretty-quick` or your own prettifier command to the script to post-process the schema code.
 
 ## Running the script
 
@@ -122,26 +125,28 @@ The functions it generates are below. The names of the functions are based on th
 ## Important Assumptions
 
 This package makes assumptions of how you structure your Airtable. We note them here as best as possible
+
 1. Linked Record relationship is accurate (one-to-many vs one-to-one)
 2. Column Names do not have any special characters not accounted for (detailed under Record Transformations)
 3. There are no two column names that would map to the same Javascript-y name. For example, "First Name" and "First Name?" would both map to "firstName" and isn't supported
 
 ## Manual Mode
 
-If you'd prefer not to use one of the two automatic modes, the schema generator will instead look for a file called `schemaRaw.json` in your specified `input` folder. In order to generate your schema, do the following: 
+If you'd prefer not to use one of the two automatic modes, the schema generator will instead look for a file called `schemaRaw.json` in your specified `input` folder. In order to generate your schema, do the following:
+
 1. Navigate to https://airtable.com/<YOUR_BASE_ID>/api/docs
 2. Open the Javascript console (Cmd-Option-J on Chrome for Macs)
 3. Run this command (it will copy the result to your clipboard): `copy(_.mapValues(application.tablesById, table => _.set(_.omit(table, ['sampleRows']),'columns',_.map(table.columns, item =>_.set(item, 'foreignTable', _.get(item, 'foreignTable.id'))))));`
 4. Paste the result into your `schemaRaw.json` file
 5. Run `yarn generate-schema`
 
-You will need to repeat the steps above each time the airtable schema updates and you want to regenerate changes. If you do not update `schemaRaw.json`, the schema generation will not fail, but rather generate based on an outdated schema. 
+You will need to repeat the steps above each time the airtable schema updates and you want to regenerate changes. If you do not update `schemaRaw.json`, the schema generation will not fail, but rather generate based on an outdated schema.
 
 Note: It's recommended to add `schemaRaw.json` to your `.gitignore` file
 
 ## Schema Metadata
 
-Optionally, you can add a `schemaMeta` parameter to your `airtable-schema-generator` entry in `package.json`. This object lets you specify info about custom helper functions in `request.js`.  Sample Structure: 
+Optionally, you can add a `schemaMeta` parameter to your `airtable-schema-generator` entry in `package.json`. This object lets you specify info about custom helper functions in `request.js`. Sample Structure:
 
 ```
 {
@@ -156,7 +161,9 @@ Optionally, you can add a `schemaMeta` parameter to your `airtable-schema-genera
 ```
 
 ### Lookup Fields
+
 The `lookupFields` meta attribute specifies which fields you would like to create a custom `getRecordsByAttribute` helper function for. For example, one of the functions the above `schemaMeta` would create might look like:
+
 ```
 export const getAnnouncementsByProjectGroup = async value => {
   return getRecordsByAttribute(
@@ -166,22 +173,25 @@ export const getAnnouncementsByProjectGroup = async value => {
   );
 };
 ```
-This is in addition to the two default "get" functions created. 
+
+This is in addition to the two default "get" functions created.
 
 ## Record Transformations
 
-To make working with records easier, this package includes functions that transform Airtable records after a Read action and before a Create/Update action. That transformation consists of the following: 
+To make working with records easier, this package includes functions that transform Airtable records after a Read action and before a Create/Update action. That transformation consists of the following:
 
 #### 1. Javascript-y Column Names
 
-The transformation changes the column names of the record from the column name on Airtable (usually human readable) to the most likely variable name given basic Javascript conventions. 
+The transformation changes the column names of the record from the column name on Airtable (usually human readable) to the most likely variable name given basic Javascript conventions.
 
-Examples: 
+Examples:
+
 - "First Name" -> "firstName"
 - "Is Public?" -> "isPublic"
 
-The current definition of the map from Human Readable to Javascript-y names is: 
-1. Remove Special Characters: `(`, `)`, ` `, `"`, `'`, `?` (more can be added through a PR)
+The current definition of the map from Human Readable to Javascript-y names is:
+
+1. Remove Special Characters: `(`, `)`, ``, `"`, `'`, `?` (more can be added through a PR)
 2. Lowercase Entire String
 3. Split on spaces
 4. Capitalize first character of each word except the first
@@ -189,19 +199,19 @@ The current definition of the map from Human Readable to Javascript-y names is:
 
 #### 2. Accurate Linked Record Column Names
 
-Linked Records on Airtable are usually named something like "Author" or "Project", which would make the corresponding javascript-y name "author" or "project". The most expressive name, however, given how they come back in the API response, would be "authorId" or "projectId". 
+Linked Records on Airtable are usually named something like "Author" or "Project", which would make the corresponding javascript-y name "author" or "project". The most expressive name, however, given how they come back in the API response, would be "authorId" or "projectId".
 
 Record transformation accounts this, pluralizing it when the record is marked as a one-to-many relationship
 
 #### 3. Wraps/Unwraps one-to-one Linked Record Values
 
-Even though Airtable allows you to change a linked record to a one-to-many relationship, the values from the api are still considered an array, meaning you have to unwrap a value from an array when reading from airtable and re-wrap it when writing. 
+Even though Airtable allows you to change a linked record to a one-to-many relationship, the values from the api are still considered an array, meaning you have to unwrap a value from an array when reading from airtable and re-wrap it when writing.
 
 Record transformation does this wrapping and unwrapping for you based on the type of relationship found on Airtable.
 
 ## Custom Filters and Sorts
 
-For all `getAllRecords` functions, you can provide optional `filterByFormula` and `sort` props that will be passed to the base airtable functions. 
+For all `getAllRecords` functions, you can provide optional `filterByFormula` and `sort` props that will be passed to the base airtable functions.
 
 For any `getAllRecordsByAttribute` functions (generated by lookup fields), you can provide an optional `sort` prop.
 

--- a/airtable.js
+++ b/airtable.js
@@ -194,6 +194,9 @@ function deleteRecord(table, id) {
 }
 
 export {
+  base,
+  fromAirtableFormat,
+  toAirtableFormat,
   createRecord,
   getAllRecords,
   getRecordById,

--- a/airtable.js
+++ b/airtable.js
@@ -8,18 +8,18 @@
 
   If you're adding a new function: make sure you add a corresponding test (at least 1) for it in airtable.spec.js
 */
-import Airtable from 'airtable';
+import Airtable from 'REPLACE_IMPORT_LIB';
 import { Columns } from './schema';
 
-const BASE_ID = 'REPLACE_BASE_ID';
-const VIEW = 'REPLACE_VIEW';
-const ENDPOINT_URL = 'https://api.airtable.com';
+const BASE_ID = process.env.REACT_APP_AIRTABLE_BASE_ID;
 
-const apiKey = process.env.REACT_APP_AIRTABLE_API_KEY;
+const API_KEY = 'REPLACE_API_KEY';
+const ENDPOINT_URL = 'REPLACE_ENDPOINT';
+const VIEW = 'REPLACE_VIEW';
 
 Airtable.configure({
   endpointUrl: ENDPOINT_URL,
-  apiKey
+  apiKey: API_KEY,
 });
 
 const base = Airtable.base(BASE_ID);
@@ -38,7 +38,7 @@ const fromAirtableFormat = (record, table) => {
   const invertedColumns = Object.keys(columns).reduce(
     (obj, key) => ({
       ...obj,
-      [columns[key].name]: { name: key, type: columns[key].type }
+      [columns[key].name]: { name: key, type: columns[key].type },
     }),
     {}
   );
@@ -62,7 +62,7 @@ const fromAirtableFormat = (record, table) => {
 
     return {
       ...obj,
-      [jsFormattedName.name]: value
+      [jsFormattedName.name]: value,
     };
   }, {});
 };
@@ -99,10 +99,10 @@ function createRecord(table, record) {
   const transformedRecord = toAirtableFormat(record, table);
   return base(table)
     .create([{ fields: transformedRecord }])
-    .then(records => {
+    .then((records) => {
       return records[0].getId();
     })
-    .catch(err => {
+    .catch((err) => {
       throw err;
     });
 }
@@ -112,17 +112,17 @@ function getAllRecords(table, filterByFormula = '', sort = []) {
     .select({
       view: VIEW,
       filterByFormula,
-      sort
+      sort,
     })
     .all()
-    .then(records => {
+    .then((records) => {
       if (records === null || records.length < 1) {
         return [];
       }
 
-      return records.map(record => fromAirtableFormat(record.fields, table));
+      return records.map((record) => fromAirtableFormat(record.fields, table));
     })
-    .catch(err => {
+    .catch((err) => {
       throw err;
     });
 }
@@ -131,10 +131,10 @@ function getAllRecords(table, filterByFormula = '', sort = []) {
 function getRecordById(table, id) {
   return base(table)
     .find(id)
-    .then(record => {
+    .then((record) => {
       return fromAirtableFormat(record.fields, table);
     })
-    .catch(err => {
+    .catch((err) => {
       throw err;
     });
 }
@@ -148,18 +148,18 @@ function getRecordsByAttribute(table, fieldType, field, sort = []) {
     .select({
       view: VIEW,
       filterByFormula: `{${fieldType}}='${field}'`,
-      sort
+      sort,
     })
     .all()
-    .then(records => {
+    .then((records) => {
       if (!records || records.length < 1) {
         // No need for this to throw an error, sometimes there're just no values
         return [];
       }
 
-      return records.map(record => fromAirtableFormat(record.fields, table));
+      return records.map((record) => fromAirtableFormat(record.fields, table));
     })
-    .catch(err => {
+    .catch((err) => {
       throw err;
     });
 }
@@ -171,13 +171,13 @@ function updateRecord(table, id, updatedRecord) {
     .update([
       {
         id,
-        fields: transformedRecord
-      }
+        fields: transformedRecord,
+      },
     ])
-    .then(records => {
+    .then((records) => {
       return records[0].id;
     })
-    .catch(err => {
+    .catch((err) => {
       throw err;
     });
 }
@@ -185,10 +185,10 @@ function updateRecord(table, id, updatedRecord) {
 function deleteRecord(table, id) {
   return base(table)
     .destroy([id])
-    .then(records => {
+    .then((records) => {
       return records[0].fields;
     })
-    .catch(err => {
+    .catch((err) => {
       throw err;
     });
 }
@@ -199,5 +199,5 @@ export {
   getRecordById,
   getRecordsByAttribute,
   updateRecord,
-  deleteRecord
+  deleteRecord,
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -57,7 +57,7 @@ function readSettings() {
   return {
     outputFolder: settings.output,
     inputFolder: settings.input,
-    baseId: process.env.AIRTABLE_BASE_ID,
+    baseId: process.env.REACT_APP_AIRTABLE_BASE_ID,
     mode: settings.mode,
     defaultView: settings.defaultView || 'Grid view',
     schemaMeta: settings.schemaMeta || {},

--- a/bin/index.js
+++ b/bin/index.js
@@ -5,12 +5,12 @@ const { existsSync, readFileSync } = require('fs');
 const {
   generateRequestFile,
   generateAirtableFile,
-  generateSchemaFile
+  generateSchemaFile,
 } = require('../lib/generators');
 
 // Load regular config vars
 require('dotenv').config({
-  path: '.env'
+  path: '.env',
 });
 
 const script = `copy(_.mapValues(application.tablesById, table => _.set(_.omit(table, ['sampleRows']),'columns',_.map(table.columns, item =>_.set(item, 'foreignTable', _.get(item, 'foreignTable.id'))))));`;
@@ -23,7 +23,7 @@ function readSettings() {
 
   // Load regular config vars
   require('dotenv').config({
-    path: settings.envFileName || '.env'
+    path: settings.envFileName || '.env',
   });
 
   if (!settings || !settings.output || !settings.mode) {
@@ -42,12 +42,16 @@ function readSettings() {
     );
   }
 
-  if (!process.env.AIRTABLE_BASE_ID) {
-    console.log("Couldn't find 'AIRTABLE_BASE_ID' environment variable");
+  if (!process.env.REACT_APP_AIRTABLE_BASE_ID) {
+    console.log(
+      "Couldn't find 'REACT_APP_AIRTABLE_BASE_ID' environment variable"
+    );
     console.log(
       'Please add the key to the `.env` file as specified in the README'
     );
-    throw new Error("Couldn't find AIRTABLE_BASE_ID environment variable");
+    throw new Error(
+      "Couldn't find REACT_APP_AIRTABLE_BASE_ID environment variable"
+    );
   }
 
   return {
@@ -56,7 +60,9 @@ function readSettings() {
     baseId: process.env.AIRTABLE_BASE_ID,
     mode: settings.mode,
     defaultView: settings.defaultView || 'Grid view',
-    schemaMeta: settings.schemaMeta || {}
+    schemaMeta: settings.schemaMeta || {},
+    airlock: settings.airlock || false,
+    overwrite: settings.overwrite === undefined ? true : settings.overwrite,
   };
 }
 
@@ -65,14 +71,14 @@ function simplifySchema(schema) {
   return Object.keys(schema).reduce((result, tableId) => {
     let table = schema[tableId];
     result[table.name] = {
-      columns: table.columns.map(c => ({
+      columns: table.columns.map((c) => ({
         // Append relationship to foreign key type
         type:
           c.type === 'foreignKey'
             ? c.type + '-' + c.typeOptions.relationship
             : c.type,
-        name: c.name
-      }))
+        name: c.name,
+      })),
     };
     return result;
   }, {});
@@ -124,7 +130,7 @@ async function getSchemaFromAirtable(settings) {
       email: process.env.AIRTABLE_EMAIL,
       password: process.env.AIRTABLE_PASSWORD,
       baseId: settings.baseId,
-      headless: mode.includes('headless')
+      headless: mode.includes('headless'),
     });
   }
 }
@@ -152,7 +158,11 @@ async function main(settings) {
   // Generate outputs
   generateSchemaFile(simplifiedSchema, settings);
   generateRequestFile(simplifiedSchema, settings);
-  generateAirtableFile(settings);
+
+  // Don't overwrite file if setting is false
+  if (settings.overwrite) {
+    generateAirtableFile(settings);
+  }
   console.log('Finished Generating Files!');
 }
 

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -3,7 +3,7 @@ const { writeFile, readFileSync } = require('fs');
 const { writeJson } = require('fs-extra');
 const path = require('path');
 
-const errCatch = err => {
+const errCatch = (err) => {
   if (err) {
     console.log(err);
   }
@@ -12,10 +12,24 @@ const errCatch = err => {
 function generateAirtableFile(settings) {
   const airtablePath = path.resolve(__dirname, '../airtable.js');
   const airtableContent = readFileSync(airtablePath);
-  const airtableOutput = airtableContent
+  let airtableOutput = airtableContent
     .toString()
-    .replace('REPLACE_BASE_ID', settings.baseId)
-    .replace('REPLACE_VIEW', settings.defaultView);
+    .replace('REPLACE_VIEW', settings.defaultView)
+    .replace(
+      'REPLACE_IMPORT_LIB',
+      settings.airlock ? '@calblueprint/airlock' : 'airtable'
+    )
+    .replace(
+      "'REPLACE_ENDPOINT'",
+      settings.airlock
+        ? 'process.env.REACT_APP_ENDPOINT_URL'
+        : "'https://api.airtable.com'"
+    )
+    .replace(
+      "'REPLACE_API_KEY'",
+      settings.airlock ? "'airlock'" : 'process.env.REACT_APP_API_KEY'
+    );
+
   const savePath = path.resolve(settings.outputFolder, 'airtable.js');
   writeFile(savePath, airtableOutput, errCatch);
 }
@@ -30,9 +44,9 @@ function generateRequestFile(schema, settings) {
 
   // For each CRUD function, call the corresponding snippet function on each table in schema
   // and append to fileContents.
-  ['create', 'read', 'update', 'delete'].forEach(fn => {
+  ['create', 'read', 'update', 'delete'].forEach((fn) => {
     fileContents += snippets[`${fn}RecordsHeader`];
-    tables.forEach(tableName => {
+    tables.forEach((tableName) => {
       let cleanName = snippets.cleanTableName(tableName);
       fileContents += snippets[`${fn}Record`](
         cleanName,
@@ -52,7 +66,7 @@ function generateSchemaFile(schema, settings) {
 
   // generate an object to represent Airtable Table Names
   fileContents += snippets.tableHeader;
-  tables.forEach(tableName => {
+  tables.forEach((tableName) => {
     fileContents += snippets.tableConstant(tableName);
   });
   fileContents += snippets.generalConstantsFooter;
@@ -60,7 +74,7 @@ function generateSchemaFile(schema, settings) {
   // generate an object to represent mapping between
   // jsFormatted column names and Airtable column names
   fileContents += snippets.columnsHeader;
-  tables.forEach(tableName => {
+  tables.forEach((tableName) => {
     fileContents += snippets.columnConstant(
       tableName,
       schema[tableName].columns
@@ -74,5 +88,5 @@ function generateSchemaFile(schema, settings) {
 module.exports = {
   generateRequestFile,
   generateSchemaFile,
-  generateAirtableFile
+  generateAirtableFile,
 };

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -22,7 +22,7 @@ function generateAirtableFile(settings) {
     .replace(
       "'REPLACE_ENDPOINT'",
       settings.airlock
-        ? 'process.env.REACT_APP_ENDPOINT_URL'
+        ? 'process.env.REACT_APP_AIRTABLE_ENDPOINT_URL'
         : "'https://api.airtable.com'"
     )
     .replace(

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -27,7 +27,7 @@ function generateAirtableFile(settings) {
     )
     .replace(
       "'REPLACE_API_KEY'",
-      settings.airlock ? "'airlock'" : 'process.env.REACT_APP_API_KEY'
+      settings.airlock ? "'airlock'" : 'process.env.REACT_APP_AIRTABLE_API_KEY'
     );
 
   const savePath = path.resolve(settings.outputFolder, 'airtable.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable-schema-generator",
-  "version": "1.3.0",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable-schema-generator",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "A helper script to scrape your airtable schema and generate helper utility files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR Adds two settings: 
`airlock`: boolean value deciding whether to generate regular or airlock version of `airtable.js`
and 
`overwrite`: boolean value deciding whether to overwrite existing version of `airtable.js`

Airlock support includes a new environment variable (for endpoint url) and one less environment variable (for api key)

Note: This version has already been published as v1.4 LOL