### PR TITLE
Add support for pluralize & depluralize exceptions in `snippets.js`

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,12 +5,12 @@ const { existsSync, readFileSync } = require('fs');
 const {
   generateRequestFile,
   generateAirtableFile,
-  generateSchemaFile
+  generateSchemaFile,
 } = require('../lib/generators');
 
 // Load regular config vars
 require('dotenv').config({
-  path: '.env'
+  path: '.env',
 });
 
 const script = `copy(_.mapValues(application.tablesById, table => _.set(_.omit(table, ['sampleRows']),'columns',_.map(table.columns, item =>_.set(item, 'foreignTable', _.get(item, 'foreignTable.id'))))));`;
@@ -23,7 +23,7 @@ function readSettings() {
 
   // Load regular config vars
   require('dotenv').config({
-    path: settings.envFileName || '.env'
+    path: settings.envFileName || '.env',
   });
 
   if (!settings || !settings.output || !settings.mode) {
@@ -56,7 +56,8 @@ function readSettings() {
     baseId: process.env.AIRTABLE_BASE_ID,
     mode: settings.mode,
     defaultView: settings.defaultView || 'Grid view',
-    schemaMeta: settings.schemaMeta || {}
+    schemaMeta: settings.schemaMeta || {},
+    exceptions: settings.exceptions || {},
   };
 }
 
@@ -65,14 +66,14 @@ function simplifySchema(schema) {
   return Object.keys(schema).reduce((result, tableId) => {
     let table = schema[tableId];
     result[table.name] = {
-      columns: table.columns.map(c => ({
+      columns: table.columns.map((c) => ({
         // Append relationship to foreign key type
         type:
           c.type === 'foreignKey'
             ? c.type + '-' + c.typeOptions.relationship
             : c.type,
-        name: c.name
-      }))
+        name: c.name,
+      })),
     };
     return result;
   }, {});
@@ -124,7 +125,7 @@ async function getSchemaFromAirtable(settings) {
       email: process.env.AIRTABLE_EMAIL,
       password: process.env.AIRTABLE_PASSWORD,
       baseId: settings.baseId,
-      headless: mode.includes('headless')
+      headless: mode.includes('headless'),
     });
   }
 }

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -36,6 +36,7 @@ function generateRequestFile(schema, settings) {
       let cleanName = snippets.cleanTableName(tableName);
       fileContents += snippets[`${fn}Record`](
         cleanName,
+        settings.exceptions || {},
         settings.schemaMeta[tableName] || {}
       );
     });
@@ -66,7 +67,8 @@ function generateSchemaFile(schema, settings) {
   tables.forEach((tableName) => {
     fileContents += snippets.columnConstant(
       tableName,
-      schema[tableName].columns
+      schema[tableName].columns,
+      settings.exceptions
     );
   });
   fileContents += snippets.generalConstantsFooter;

--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -1,5 +1,5 @@
-// Convert column name to javascript-usable name
-const cleanColumnName = (column) => {
+// Convert column name to JavaScript-usable name
+const cleanColumnName = (column, exceptions) => {
   let cleanName = column.name
     .toLowerCase()
     .split(' ')
@@ -9,7 +9,7 @@ const cleanColumnName = (column) => {
 
   if (column.type && column.type.includes('foreignKey')) {
     return column.type.includes('many')
-      ? cleanName.substr(0, cleanName.length - 1) + 'Ids'
+      ? depluralize(cleanName, exceptions) + 'Ids'
       : cleanName + 'Id';
   } else {
     return cleanName;
@@ -18,8 +18,19 @@ const cleanColumnName = (column) => {
 
 const cleanTableName = (name) => name.replace(/\(|\)|\s/g, '');
 
-const pluralize = (name) =>
-  name.charAt(name.length - 1) === 's' ? name : name.concat('s');
+const pluralize = (name, exceptions) =>
+  exceptions.pluralize && exceptions.pluralize.includes(name)
+    ? name
+    : name.charAt(name.length - 1) === 's'
+    ? name
+    : name.concat('s');
+
+const depluralize = (name, exceptions) =>
+  exceptions.depluralize && exceptions.depluralize.includes(name)
+    ? name
+    : name.charAt(name.length - 1) === 's'
+    ? name.substr(0, name.length - 1)
+    : name;
 
 const lowercaseFirstChar = (s) => {
   return s.charAt(0).toLowerCase() + s.substring(1);
@@ -80,12 +91,15 @@ import {
  */
 `,
 
-  createRecord: (tableName) => `
+  createRecord: (tableName, exceptions) => `
 export const create${tableName} = async (record) => {
   return createRecord(Tables.${tableName}, record);
 };
 
-export const createMany${pluralize(tableName)} = async (records) => {
+export const createMany${pluralize(
+    tableName,
+    exceptions
+  )} = async (records) => {
   const createPromises = [];
   const numCalls = Math.ceil(records.length / 10);
   for (let i = 0; i < numCalls; i += 1) {
@@ -96,14 +110,15 @@ export const createMany${pluralize(tableName)} = async (records) => {
   return Promise.all(createPromises);
 };
 `,
-  readRecord: (tableName, { lookupFields }) => {
+  readRecord: (tableName, exceptions, { lookupFields }) => {
     let result = `
 export const get${tableName}ById = async (id) => {
   return getRecordById(Tables.${tableName}, id);
 };
 
 export const get${pluralize(
-      tableName
+      tableName,
+      exceptions
     )}ByIds = async ( ids, filterByFormula = '', sort = []
 ) => {
   let formula = ${'`OR(${'}ids.reduce(
@@ -115,7 +130,8 @@ export const get${pluralize(
 };
 
 export const getAll${pluralize(
-      tableName
+      tableName,
+      exceptions
     )} = async (filterByFormula = '', sort = []) => {
   return getAllRecords(Tables.${tableName}, filterByFormula, sort);
 };
@@ -124,7 +140,7 @@ export const getAll${pluralize(
       lookupFields.forEach((field) => {
         let cleanName = cleanColumnName({ name: field });
         result += `
-export const get${pluralize(tableName)}By${cleanName} = async (
+export const get${pluralize(tableName, exceptions)}By${cleanName} = async (
   value,
   filterByFormula = '',
   sort = []
@@ -138,12 +154,15 @@ export const get${pluralize(tableName)}By${cleanName} = async (
     }
     return result;
   },
-  updateRecord: (tableName) => `
+  updateRecord: (tableName, exceptions) => `
 export const update${tableName} = async (id, recordUpdates) => {
   return updateRecord(Tables.${tableName}, id, recordUpdates);
 };
 
-export const updateMany${pluralize(tableName)} = async (recordUpdates) => {
+export const updateMany${pluralize(
+    tableName,
+    exceptions
+  )} = async (recordUpdates) => {
   const updatePromises = [];
   const numCalls = Math.ceil(recordUpdates.length / 10);
   for (let i = 0; i < numCalls; i += 1) {
@@ -168,11 +187,11 @@ export const delete${tableName} = async (id) => {
     let cleanName = cleanTableName(tableName);
     return `\t${cleanName}: '${tableName}',\n`;
   },
-  columnConstant: (tableName, columns) => {
+  columnConstant: (tableName, columns, exceptions) => {
     let result = `\t"${tableName}": {\n`;
     columns.forEach((c) => {
       // Lowercase the clean name so follows JS conventions
-      let cleanName = lowercaseFirstChar(cleanColumnName(c));
+      let cleanName = lowercaseFirstChar(cleanColumnName(c, exceptions));
       result += `\t\t${cleanName}: {name:\`${c.name}\`, type:\`${c.type}\`},\n`;
     });
     result += '\t},\n';

--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -92,7 +92,7 @@ import {
 `,
 
   createRecord: (tableName, exceptions) => `
-export const create${tableName} = async (record) => {
+export const create${depluralize(tableName, exceptions)} = async (record) => {
   return createRecord(Tables.${tableName}, record);
 };
 
@@ -112,7 +112,7 @@ export const createMany${pluralize(
 `,
   readRecord: (tableName, exceptions, { lookupFields }) => {
     let result = `
-export const get${tableName}ById = async (id) => {
+export const get${depluralize(tableName, exceptions)}ById = async (id) => {
   return getRecordById(Tables.${tableName}, id);
 };
 
@@ -155,7 +155,10 @@ export const get${pluralize(tableName, exceptions)}By${cleanName} = async (
     return result;
   },
   updateRecord: (tableName, exceptions) => `
-export const update${tableName} = async (id, recordUpdates) => {
+export const update${depluralize(
+    tableName,
+    exceptions
+  )} = async (id, recordUpdates) => {
   return updateRecord(Tables.${tableName}, id, recordUpdates);
 };
 
@@ -173,8 +176,8 @@ export const updateMany${pluralize(
   return Promise.all(updatePromises);
 };
 `,
-  deleteRecord: (tableName) => `
-export const delete${tableName} = async (id) => {
+  deleteRecord: (tableName, exceptions) => `
+export const delete${depluralize(tableName, exceptions)} = async (id) => {
   return deleteRecord(Tables.${tableName}, id);
 };`,
   tableHeader: `/*


### PR DESCRIPTION
Closes #26 , closes #27 

With the #26 fix and depluralizing for the 'singular' helper functions, we no longer make any assumptions about whether your Airtable base follows the convention of naming with singular case or plural case (^:

(C/P from README updates)

Because the function names imply whether to use a single record or multiple records, we pluralize and depluralize table names when generating `request.js`. The implementation of pluralization and depluralization is very simple - we just check if the tablename ends in the letter 's'. 

However, English can be odd - for example, a table named "Feedback" would not need to be pluralized. On the other hand, "News" shouldn't be de-pluralized. Thus, you can specify exceptions in the generator settings in `package.json`. It should be in this format:

```json
"exceptions": {
      "pluralize": ["Feedback", "Testing"],
      "depluralize": ["News"]
    }
```

For example, this input would have an output in `request.js` of:

```javascript
// pluralize exception:
export const createFeedback ...
export const createManyFeedback ...

// depluralize exception
export const createNews ...
export const createManyNews ...

// no exception
export const createClerk ...
export const createManyClerks ...
```

We don't support specialized pluralization or depluralization to handle cases such as "Sites Browsed".