### PR TITLE
Fix getRecordsByAttribute formula formatting

### DIFF
--- a/airtable.js
+++ b/airtable.js
@@ -177,7 +177,7 @@ function getRecordsByAttribute(
       view: VIEW,
       filterByFormula: filterByFormula
         ? `AND(${filterByFormula}, {${fieldType}}=${fieldValue})`
-        : `{${fieldType}}=${fieldValue}`,
+        : `({${fieldType}}="${fieldValue}")`,
       sort,
     })
     .all()


### PR DESCRIPTION
Addresses an issue with formula formatting that failed to handle phone number formats like (XXX) XXX-XXXX.